### PR TITLE
1) update README, add example code, 2) generate txt for thin archive under corresponding kmod and vmlinux dir

### DIFF
--- a/examples/llpatch-callback-shadow-var.c
+++ b/examples/llpatch-callback-shadow-var.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *     Author: Yonghyun Hwang <yonghyun@google.com>
+ */
+/*
+ * This file implements example code to show
+ *
+ *   1) how to implement callbacks for kernel livepatch,
+ *
+ *   2) how to access global variables defined in kernel module or vmlinux.
+ *
+ * For more details, refer to ${llpatch}/templates/llpatch.h and
+ * ${llpatch}/templates/llpatch-callbacks.c
+ */
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/livepatch.h>
+
+#include "llpatch.h"
+
+typedef char c_array_t[PAGE_SIZE];
+
+// c_array_t: type of global variable defined in kernel module
+// apple_fruit: alias to the variable
+// kernel/livepatch/test/test-attr-apple.c: path to the file w/ the variable
+// fruit: name of variable in the file for the kernel module
+LLPATCH_DECLARE_SYMBOL(c_array_t, apple_fruit,
+		kernel/livepatch/test/test-attr-apple.c, fruit);
+
+LLPATCH_DECLARE_SYMBOL(
+		c_array_t, banana_fruit,
+		kernel/livepatch/test/test-attr-banana.c, fruit);
+
+#define SHADOW_DATA_ID 1
+
+/* Executed on object patching (ie, patch enablement) */
+static int pre_patch_callback(struct klp_object *obj)
+{
+	char *shadow_apple, *shadow_banana;
+
+	pr_info("\nAccessing llpatch symbol in %s\n", __func__);
+
+	pr_info("apple_fruit is %s at %p\n",
+		LLPATCH_SYMBOL(apple_fruit),
+		LLPATCH_SYMBOL(apple_fruit));
+	pr_info("banana_fruit is %s at %p\n",
+		LLPATCH_SYMBOL(banana_fruit),
+		LLPATCH_SYMBOL(banana_fruit));
+
+	/*
+	 * @obj:	pointer to parent object
+	 * @id:		data identifier
+	 * @size:	size of attached data
+	 * @gfp_flags:	GFP mask for allocation
+	 * @ctor:	custom constructor to initialize the shadow data (optional)
+	 * @ctor_data:	pointer to any data needed by @ctor (optional)
+	 */
+	shadow_apple = klp_shadow_alloc(/*obj*/LLPATCH_SYMBOL(apple_fruit),
+			/*id*/SHADOW_DATA_ID,
+			/*size*/sizeof(c_array_t),
+			/*gfp_flags*/GFP_KERNEL,
+			/*ctor*/NULL, /*ctor_data*/NULL);
+	strcpy(shadow_apple, "Pink Lady");
+	pr_info("shadow for apple is added\n");
+
+	shadow_banana = klp_shadow_alloc(/*obj*/LLPATCH_SYMBOL(banana_fruit),
+			/*id*/SHADOW_DATA_ID,
+			/*size*/sizeof(c_array_t),
+			/*gfp_flags*/GFP_KERNEL,
+			/*ctor*/NULL, /*ctor_data*/NULL);
+	strcpy(shadow_banana, "Plantain");
+	pr_info("shadow for banana is added\n");
+
+	pr_info("Done in %s\n\n", __func__);
+
+	return 0;
+}
+
+/* Executed after object patching */
+static void post_patch_callback(struct klp_object *obj)
+{
+}
+
+/* Executed on object unpatching */
+static void pre_unpatch_callback(struct klp_object *obj)
+{
+}
+
+/* Executed after object unpatching */
+static void post_unpatch_callback(struct klp_object *obj)
+{
+	pr_info("\nAccessing llpatch symbol in %s\n", __func__);
+
+	pr_info("freeing shadow data for apple at %p\n", LLPATCH_SYMBOL(apple_fruit));
+	klp_shadow_free(LLPATCH_SYMBOL(apple_fruit), SHADOW_DATA_ID, NULL);
+
+	pr_info("freeing shadow data for banana at %p\n", LLPATCH_SYMBOL(banana_fruit));
+	klp_shadow_free(LLPATCH_SYMBOL(banana_fruit), SHADOW_DATA_ID, NULL);
+
+	pr_info("Done in %s\n\n", __func__);
+}

--- a/llpatch
+++ b/llpatch
@@ -581,7 +581,8 @@ function generate_thin_archive_txt()
 		return 0
 	fi
 
-	local -r __THIN_ARCHIVE_TXT="${G_TMP_DIR}/$(basename "${__THIN_ARCHIVE}").${G_SUFFIX_TAR}"
+	local -r __KLP_OBJ_ROOT="$(get_klp_obj_root "${__OBJ_PARENT}")"
+	local -r __THIN_ARCHIVE_TXT="${__KLP_OBJ_ROOT}/$(basename "${__THIN_ARCHIVE}").${G_SUFFIX_TAR}"
 	if [[ -f ${__THIN_ARCHIVE_TXT} ]]; then
 		eval "${__RETVAL}"="${__THIN_ARCHIVE_TXT}"
 		return 0
@@ -885,7 +886,7 @@ function package_build()
 	util::log_info "Build ${LIVEPATCH_OBJ} and resolve LLPatch symbols"
 	run_command "${BUILD_COMMAND[@]}" -C "${G_KDIR}" "${LIVEPATCH_OBJ}"
 
-	cat "${G_TMP_DIR}/"*".${G_SUFFIX_TAR}" >| "${G_TMP_TAR_FILE}"
+	cat *".${G_SUFFIX_TAR}" >| "${G_TMP_TAR_FILE}"
 	run_command "${G_LIVEPATCH_BIN}" fixup -q \
 				--symbol_map="${KLP_OBJ_ROOT}/${G_LLPATCH_SYMBOL_MAP_FILE}" \
 				--thin_archive="${G_TMP_TAR_FILE}" \

--- a/llpatch-merge
+++ b/llpatch-merge
@@ -488,8 +488,11 @@ function build_livepatch()
 
 	run_command "${BUILD_COMMAND[@]}" -C "${G_KDIR}" "${LIVEPATCH_OBJ}"
 
-	# TODO: we need thin archive files here. need to add a new option to get dir for thin archives
-	>| "${G_TMP_TAR_FILE}"
+	local klp_dir=""
+	for klp_dir in ${G_KLP_DIRS[@]}; do
+		cat "${klp_dir}/"*".${G_SUFFIX_TAR}"
+	done >| "${G_TMP_TAR_FILE}"
+
 	run_command "${G_LIVEPATCH_BIN}" fixup -q \
 				--symbol_map="${G_TMP_DIR}/${G_LLPATCH_SYMBOL_MAP_FILE}" \
 				--thin_archive="${G_TMP_TAR_FILE}" \

--- a/templates/README
+++ b/templates/README
@@ -11,5 +11,12 @@ livepatch. There are three files under this directory.
 3) Makefile.tmpl
    - makefile to build kernel livepatch.
 
+4) llpatch.h
+   - defines macro for LLpatch symbols
+
+5) llpatch-callbacks.c
+   - implements default callbacks for kernel livepatch
+   - this can be tweaked to implement customized callbacks
+
 Each template contains {{MARKER}} in it hoping that they are replaced by
 either `llpatch` or `livepatch gen` command.


### PR DESCRIPTION
Recent commits implement new features to support livepatch callbacks and LLpatch symbols
for accessing global variable defined kernel module or vmlinux. This commit updates
READMEs and add example code for the callbacks.